### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ $results = FirebaseNotification::unsubscribeToTopic($topic, $registrationTokens)
 ```
 Removes the subscription of the tokens from the given topic.
 
+### Configuration for Asynchronous Requests
+
+For performance optimizations when sending notifications to large numbers of tokens, the package supports asynchronous multi-token requests.
+
+To enable this feature, configure the `async_requests` option in the config file:
+
+```php
+return [
+    // Other configurations...
+
+    'async_requests' => env('CLOUD_MESSAGE_ASYNC_REQUESTS', false),
+];
+```
+
+You will need to ensure your queue worker is running to process these asynchronous jobs. From the command line, run: `php artisan queue:work` 
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,16 @@
     "description": "A Laravel package for sending Firebase and Huawei notifications.",
     "keywords": [
         "medianet-dev",
-        "cloud-message"
+        "cloud-message",
+        "fcm",
+        "laravel",
+        "fcm",
+        "firebase",
+        "push",
+        "notification",
+        "fcm",
+        "high",
+        "priority"
     ],
     "homepage": "https://github.com/medianet-dev/cloud-message",
     "license": "MIT",

--- a/config/cloud_message.php
+++ b/config/cloud_message.php
@@ -22,4 +22,8 @@ return [
 
     // Enable or disable API logs
     'with_log' => env('CLOUD_MESSAGE_WITH_LOG', false),
+
+    // Enable or disable async requests
+    'async_requests' => env('CLOUD_MESSAGE_ASYNC_REQUESTS', false),
+
 ];

--- a/src/Drivers/Notification.php
+++ b/src/Drivers/Notification.php
@@ -10,7 +10,7 @@ trait Notification
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        if ($method == 'POST') {
+        if ('POST' == $method) {
             curl_setopt($ch, CURLOPT_POST, true);
         }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -21,22 +21,27 @@ trait Notification
         curl_close($ch);
 
         if (config('cloud_message.with_log')) {
-            app('log')->debug(
-                "\n------------------- Gateway request --------------------".
-                    "\n#Url: ".$url.
-                    "\n#Method: ".$method.
-                    "\n#Headers: ".json_encode($headers).
-                    "\n#Data: ".json_encode($payload).
-                    "\n------------------- Gateway response -------------------".
-                    "\n#Status code: ".$statusCode.
-                    "\n#Response: ".json_encode($data).
-                    "\n--------------------------------------------------------"
-            );
+            self::logRequest($url, $method, $headers, $payload, $statusCode, $data);
         }
 
         return [
             'data' => $data,
-            'status' => $statusCode == 200
+            'status' => 200 == $statusCode,
         ];
+    }
+
+    protected static function logRequest($url, $method, $headers, $payload, $statusCode, $data)
+    {
+        app('log')->debug(
+            "\n------------------- Gateway request --------------------".
+                "\n#Url: ".$url.
+                "\n#Method: ".$method.
+                "\n#Headers: ".json_encode($headers).
+                "\n#Data: ".$payload.
+                "\n------------------- Gateway response -------------------".
+                "\n#Status code: ".$statusCode.
+                "\n#Response: ".$data.
+                "\n--------------------------------------------------------"
+        );
     }
 }

--- a/src/Jobs/MultiTokensJob.php
+++ b/src/Jobs/MultiTokensJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MedianetDev\CloudMessage\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use MedianetDev\CloudMessage\Drivers\Notification;
+
+class MultiTokensJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+    use Notification;
+
+    protected $tokens;
+    protected $message;
+    protected $url;
+    protected $headers;
+
+    public function __construct($tokens, $message, $url, $headers)
+    {
+        $this->tokens = $tokens;
+        $this->message = $message;
+        $this->url = $url;
+        $this->headers = $headers;
+    }
+
+    public function handle()
+    {
+        foreach ($this->tokens as $mobileId) {
+            self::request($this->url, json_encode(['message' => [
+                'token' => $mobileId,
+                'notification' => $this->message,
+            ]]), $this->headers);
+        }
+    }
+}


### PR DESCRIPTION
For performance optimizations when sending notifications to large numbers of tokens, the package supports asynchronous multi-token requests.

To enable this feature, configure the `async_requests` option in the config file:

```php
return [
    // Other configurations...

    'async_requests' => env('CLOUD_MESSAGE_ASYNC_REQUESTS', false),
];
```

You will need to ensure your queue worker is running to process these asynchronous jobs. From the command line, run: `php artisan queue:work` 
