### PR TITLE
Multiple OS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,23 @@ $registrationTokens = [
     'token2'
 ];
 
-// Send via Firebase (default)
-$results = CloudMessage::sendToTokens($message, $registrationTokens);
+// Send to Android devices
+$results = CloudMessage::sendToTokens($message, $registrationTokens, 'android');
 
-// Send via Huawei
+// Send to iOS devices
+$results = CloudMessage::sendToTokens($message, $registrationTokens, 'ios');
+
+// Send to Huawei devices
 $results = CloudMessage::sendToTokens($message, $registrationTokens, 'huawei');
 ```
 
-### Using the FirebaseNotification Class Directly
+### Send to specific devices without using the Facade
 
-You can also use the `FirebaseNotification` class directly:
+You can also use the notification class directly:
 
 ```php
 use MedianetDev\CloudMessage\Drivers\FirebaseNotification;
+use MedianetDev\CloudMessage\Drivers\HuaweiNotification;
 
 $message = [
     'title' => "Your notification title",
@@ -87,29 +91,61 @@ $registrationTokens = [
 ];
 
 $results = FirebaseNotification::sendToTokens($message, $registrationTokens);
+$results = HuaweiNotification::sendToTokens($message, $registrationTokens);
 ```
 
 ### Subscribe to a Topic
 ```php
-$topic = 'guests'
+use MedianetDev\CloudMessage\Facade\CloudMessage;
+
+$topic = 'guests';
 $registrationTokens = [
     'token1',
     'token2'
 ];
 
-$results = FirebaseNotification::subscribeToTopic($topic, $registrationTokens);
+$results = CloudMessage::subscribeToTopic($topic, $registrationTokens, 'ios');
 ```
 This will subscribe the provided tokens to receive notifications for the given topic.
 
+### Send to a Topic
+```php
+use MedianetDev\CloudMessage\Facade\CloudMessage;
+
+$message = [
+    'title' => "Your notification title",
+    'body' => "Your notification body",
+];
+
+$topic = 'guests';
+
+// Send to Android devices
+$results = CloudMessage::sendToTopic($message, $topic, 'android');
+
+// Send to iOS devices
+$results = CloudMessage::sendToTopic($message, $topic, 'ios');
+
+// Send to Huawei devices
+$results = CloudMessage::sendToTopic($message, $topic, 'huawei');
+```
+This will send the notification to all devices subscribed to the given topic.
+
+
 ### Unsubscribe to a Topic
 ```php
-$topic = 'guests'
+use MedianetDev\CloudMessage\Facade\CloudMessage;
+
+$topic = 'guests';
 $registrationTokens = [
     'token1',
     'token2'
 ];
 
-$results = FirebaseNotification::unsubscribeToTopic($topic, $registrationTokens);
+// Unsubscribe Android devices
+$results = CloudMessage::unsubscribeToTopic($topic, $registrationTokens, 'android');
+
+// Unsubscribe iOS devices
+$results = CloudMessage::unsubscribeToTopic($topic, $registrationTokens, 'ios');
 ```
 Removes the subscription of the tokens from the given topic.
 

--- a/config/cloud_message.php
+++ b/config/cloud_message.php
@@ -4,9 +4,6 @@ return [
     /* This file is part of the medianet-dev/cloud-message package. */
     /* This is the configuration file for the CloudMessage package. */
 
-    // Default driver to use
-    'default_driver' => 'firebase',
-
     // Firebase settings
     'firebase' => [
         'project_id' => env('FIREBASE_PROJECT_ID'),
@@ -25,5 +22,12 @@ return [
 
     // Enable or disable async requests
     'async_requests' => env('CLOUD_MESSAGE_ASYNC_REQUESTS', false),
+
+    // Operating system types
+    'os_types' => [
+        'android' => 'android',
+        'ios' => 'ios',
+        'huawei' => 'huawei',
+    ],
 
 ];

--- a/src/Contracts/NotificationInterface.php
+++ b/src/Contracts/NotificationInterface.php
@@ -4,14 +4,46 @@ namespace MedianetDev\CloudMessage\Contracts;
 
 interface NotificationInterface
 {
-    public static function sendToAll(array $message);
+    /**
+     * Send a notification message to all devices for a given operating system.
+     *
+     * @param array  $message the notification message data
+     * @param string $os      The operating system ('android', 'ios', etc.).
+     */
+    public static function sendToAll(array $message, string $os);
 
-    public static function sendToTopic(array $message, string $topic);
+    /**
+     * Send a notification message to a specific topic for a given operating system.
+     *
+     * @param array  $message the notification message data
+     * @param string $topic   the topic to send the message to
+     * @param string $os      The operating system ('android', 'ios', etc.).
+     */
+    public static function sendToTopic(array $message, string $topic, string $os);
 
-    public static function sendToTokens(array $message, array $tokens);
+    /**
+     * Send a notification message to specific device tokens for a given operating system.
+     *
+     * @param array  $message the notification message data
+     * @param array  $tokens  the device tokens to send the message to
+     * @param string $os      The operating system ('android', 'ios', etc.).
+     */
+    public static function sendToTokens(array $message, array $tokens, string $os);
 
+    /**
+     * Subscribe device tokens to a specific topic.
+     *
+     * @param string $topic  the topic to subscribe to
+     * @param array  $tokens the device tokens to subscribe
+     */
     public static function subscribeToTopic(string $topic, array $tokens);
 
+    /**
+     * Unsubscribe device tokens from a specific topic.
+     *
+     * @param string $topic  the topic to unsubscribe from
+     * @param array  $tokens the device tokens to unsubscribe
+     */
     public static function unsubscribeToTopic(string $topic, array $tokens);
 
     // etc

--- a/src/Contracts/NotificationInterface.php
+++ b/src/Contracts/NotificationInterface.php
@@ -7,42 +7,42 @@ interface NotificationInterface
     /**
      * Send a notification message to all devices for a given operating system.
      *
-     * @param array  $message the notification message data
-     * @param string $os      The operating system ('android', 'ios', etc.).
+    * @param  array   $message  the notification message data
+    * @param  string  $os       The operating system ('android', 'ios', etc.).
      */
     public static function sendToAll(array $message, string $os);
 
     /**
      * Send a notification message to a specific topic for a given operating system.
      *
-     * @param array  $message the notification message data
-     * @param string $topic   the topic to send the message to
-     * @param string $os      The operating system ('android', 'ios', etc.).
+    * @param  array   $message  the notification message data
+    * @param  string  $topic    the topic to send the message to
+    * @param  string  $os       The operating system ('android', 'ios', etc.).
      */
     public static function sendToTopic(array $message, string $topic, string $os);
 
     /**
      * Send a notification message to specific device tokens for a given operating system.
      *
-     * @param array  $message the notification message data
-     * @param array  $tokens  the device tokens to send the message to
-     * @param string $os      The operating system ('android', 'ios', etc.).
+    * @param  array   $message  the notification message data
+    * @param  array   $tokens   the device tokens to send the message to
+    * @param  string  $os       The operating system ('android', 'ios', etc.).
      */
     public static function sendToTokens(array $message, array $tokens, string $os);
 
     /**
      * Subscribe device tokens to a specific topic.
      *
-     * @param string $topic  the topic to subscribe to
-     * @param array  $tokens the device tokens to subscribe
+    * @param  string  $topic   the topic to subscribe to
+    * @param  array   $tokens  the device tokens to subscribe
      */
     public static function subscribeToTopic(string $topic, array $tokens);
 
     /**
      * Unsubscribe device tokens from a specific topic.
      *
-     * @param string $topic  the topic to unsubscribe from
-     * @param array  $tokens the device tokens to unsubscribe
+    * @param  string  $topic   the topic to unsubscribe from
+    * @param  array   $tokens  the device tokens to unsubscribe
      */
     public static function unsubscribeToTopic(string $topic, array $tokens);
 

--- a/src/Drivers/FirebaseNotification.php
+++ b/src/Drivers/FirebaseNotification.php
@@ -14,19 +14,19 @@ class FirebaseNotification implements NotificationInterface
     private static $firebaseMessagingScope = 'https://www.googleapis.com/auth/firebase.messaging';
     private static $googleApiBaseUrl = 'https://iid.googleapis.com/iid/v1/';
 
-    public static function sendToAll(array $message)
+    public static function sendToAll(array $message, string $os)
     {
         // TODO: Send to all devices
     }
 
-    public static function sendToTopic(array $message, $topic)
+    public static function sendToTopic(array $message, string $topic, string $os)
     {
         $headers = [
-            'Authorization: Bearer ' . self::getAccessToken(),
+            'Authorization: Bearer '.self::getAccessToken(),
             'Content-Type: application/json',
         ];
 
-        $url = self::$firebaseApiBaseUrl . config('cloud_message.firebase.project_id') . '/messages:send';
+        $url = self::$firebaseApiBaseUrl.config('cloud_message.firebase.project_id').'/messages:send';
 
         if (isset($message['data'])) {
             $message['data'] = json_encode($message['data'], JSON_UNESCAPED_UNICODE);
@@ -36,28 +36,31 @@ class FirebaseNotification implements NotificationInterface
             'message' => [
                 'topic' => $topic,
                 'data' => $message,
-                'notification' => [
-                    'title' => $message['title'],
-                    'body' => $message['body'],
-                ],
             ],
         ];
+
+        if (0 === strcasecmp($os, config('cloud_message.os_types.ios'))) {
+            $data['message']['notification'] = [
+                'title' => $message['title'],
+                'body' => $message['body'],
+            ];
+        }
 
         $response = self::request($url, json_encode($data), $headers);
 
         return ['status' => $response['status']];
     }
 
-    public static function sendToTokens(array $message, array $tokens)
+    public static function sendToTokens(array $message, array $tokens, string $os)
     {
-        $url = self::$firebaseApiBaseUrl . config('cloud_message.firebase.project_id') . '/messages:send';
+        $url = self::$firebaseApiBaseUrl.config('cloud_message.firebase.project_id').'/messages:send';
         try {
             if (isset($message['data'])) {
                 $message['data'] = json_encode($message['data'], JSON_UNESCAPED_UNICODE);
             }
 
             $headers = [
-                'Authorization: Bearer ' . self::getAccessToken(),
+                'Authorization: Bearer '.self::getAccessToken(),
                 'Content-Type: application/json',
             ];
             if (config('cloud_message.async_requests')) {
@@ -87,10 +90,10 @@ class FirebaseNotification implements NotificationInterface
 
     public static function subscribeToTopic(string $topic, array $tokens)
     {
-        $url = self::$googleApiBaseUrl . ':batchAdd';
+        $url = self::$googleApiBaseUrl.':batchAdd';
 
         $headers = [
-            'Authorization: Bearer ' . self::getAccessToken(),
+            'Authorization: Bearer '.self::getAccessToken(),
             'Content-Type: application/json',
             'access_token_auth: true',
         ];
@@ -100,7 +103,7 @@ class FirebaseNotification implements NotificationInterface
 
         foreach ($chunkedTokens as $tokenGroup) {
             $data = [
-                'to' => '/topics/' . $topic,
+                'to' => '/topics/'.$topic,
                 'registration_tokens' => $tokenGroup,
             ];
 
@@ -118,10 +121,10 @@ class FirebaseNotification implements NotificationInterface
 
     public static function unsubscribeToTopic(string $topic, array $tokens)
     {
-        $url = self::$googleApiBaseUrl . ':batchRemove';
+        $url = self::$googleApiBaseUrl.':batchRemove';
 
         $headers = [
-            'Authorization: Bearer ' . self::getAccessToken(),
+            'Authorization: Bearer '.self::getAccessToken(),
             'Content-Type: application/json',
             'access_token_auth: true',
         ];
@@ -131,7 +134,7 @@ class FirebaseNotification implements NotificationInterface
 
         foreach ($chunkedTokens as $tokenGroup) {
             $data = [
-                'to' => '/topics/' . $topic,
+                'to' => '/topics/'.$topic,
                 'registration_tokens' => $tokenGroup,
             ];
 

--- a/src/Drivers/HuaweiNotification.php
+++ b/src/Drivers/HuaweiNotification.php
@@ -11,12 +11,12 @@ class HuaweiNotification implements NotificationInterface
     private static $urlAuth = 'https://login.vmall.com/oauth2/token';
     private static $pushUrl = 'https://push-api.cloud.huawei.com/v1/';
 
-    public static function sendToAll(array $message)
+    public static function sendToAll(array $message, string $os)
     {
         // TODO: Send to all devices
     }
 
-    public static function sendToTokens(array $message, array $tokens)
+    public static function sendToTokens(array $message, array $tokens, string $os)
     {
         $structureData = [];
         $structureData['validate_only'] = false;
@@ -47,7 +47,7 @@ class HuaweiNotification implements NotificationInterface
         return $result['access_token'] ?? '';
     }
 
-    public static function sendToTopic(array $message, string $topic)
+    public static function sendToTopic(array $message, string $topic, string $os)
     {
     }
 

--- a/src/Facade/CloudMessage.php
+++ b/src/Facade/CloudMessage.php
@@ -4,35 +4,47 @@ namespace MedianetDev\CloudMessage\Facade;
 
 class CloudMessage
 {
-    public static function sendToAll(array $message, string $driver = 'firebase')
+    public static function sendToAll(array $message, string $os)
     {
+        // Get driver by OS
+        $driver = self::getDriverByOs($os);
+
         // Detect driver class
         $class = self::getDriverClass($driver);
 
         // Call driver method
-        return $class::sendToAll($message);
+        return $class::sendToAll($message, $os);
     }
 
-    public static function sendToTokens(array $message, array $tokens, string $driver = 'firebase')
+    public static function sendToTokens(array $message, array $tokens, string $os)
     {
+        // Get driver by OS
+        $driver = self::getDriverByOs($os);
+
         // Detect driver class
         $class = self::getDriverClass($driver);
 
         // Call driver method
-        return $class::sendToTokens($message, $tokens);
+        return $class::sendToTokens($message, $tokens, $os);
     }
 
-    public static function sendToTopic(array $message, string $topic, string $driver = 'firebase')
+    public static function sendToTopic(array $message, string $topic, string $os)
     {
+        // Get driver by OS
+        $driver = self::getDriverByOs($os);
+
         // Detect driver class
         $class = self::getDriverClass($driver);
 
         // Call driver method
-        return $class::sendToTopic($message, $topic);
+        return $class::sendToTopic($message, $topic, $os);
     }
 
-    public static function subscribeToTopic(string $topic, array $tokens, string $driver = 'firebase')
+    public static function subscribeToTopic(string $topic, array $tokens, string $os)
     {
+        // Get driver by OS
+        $driver = self::getDriverByOs($os);
+
         // Detect driver class
         $class = self::getDriverClass($driver);
 
@@ -40,8 +52,11 @@ class CloudMessage
         return $class::subscribeToTopic($topic, $tokens);
     }
 
-    public static function unsubscribeToTopic(string $topic, array $tokens, string $driver = 'firebase')
+    public static function unsubscribeToTopic(string $topic, array $tokens, string $os)
     {
+        // Get driver by OS
+        $driver = self::getDriverByOs($os);
+
         // Detect driver class
         $class = self::getDriverClass($driver);
 
@@ -61,5 +76,22 @@ class CloudMessage
         }
 
         return $drivers[$driver];
+    }
+
+    protected static function getDriverByOs(string $os)
+    {
+        $os = strtolower($os);
+        $osTypes = config('cloud_message.os_types');
+
+        switch ($os) {
+            case strtolower($osTypes['android']):
+            case strtolower($osTypes['ios']):
+                return 'firebase';
+            case strtolower($osTypes['huawei']):
+                return 'huawei';
+            default:
+                throw new \InvalidArgumentException('OS type not supported');
+                throw new \Exception("OS type '{$os}' is not supported. Allowed values are: {$allowed}");
+        }
     }
 }


### PR DESCRIPTION
This pull request adds support for sending push notifications to different operating systems (Android, iOS, and
Huawei).

**Changes:**

*   The `CloudMessage` facade now accepts an `$os` parameter to specify the target operating system.
*   The `default_driver` configuration has been removed and replaced with `os_types` to map operating systems to drivers.
*   The `NotificationInterface` has been updated to include the `$os` parameter in its methods.
*   The `FirebaseNotification` and `HuaweiNotification` drivers have been updated to handle the `$os` parameter.
*   The `README.md` file has been updated to reflect the new changes.

**How to test:**

1.  Publish the new configuration file: `php artisan vendor:publish --provider="MedianetDev\CloudMessage\CloudMessageServiceProvider" --tag="config"`
2.  Configure your Firebase and Huawei credentials in `config/cloud_message.php`.
3.  Use the `CloudMessage` facade to send notifications to different operating systems as described in the updated `README.md` file.