### PR TITLE
Add Laravel 12 & 13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `medianet-dev/cloud-message` will be documented in this file
 
+## 2.0.0 - Unreleased
+
+### Added
+- Support for Laravel 12 and Laravel 13.
+
+### Changed
+- Minimum PHP version bumped to 8.1 (Laravel 9+ baseline; older PHP versions were already incompatible due to upstream `firebase/php-jwt` security advisories blocking older `google/apiclient` releases).
+- Minimum Laravel version is now 9.0; dropped Laravel 7 and 8 from the supported range.
+- `phpunit.xml.dist` migrated to a schema compatible with PHPUnit 9, 10, and 11.
+
+### Removed
+- Support for PHP 7.3, 7.4, and 8.0.
+- Support for Laravel 7 and Laravel 8.
+
 ## 1.0.0 - 2024-09-16
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Cloud Message is a Laravel package that provides a simple and unified way to sen
 
 ## Requirements
 
-- PHP 7.3+
-- Laravel 7.0+
+- PHP 8.1+
+- Laravel 9.x – 13.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "php": "^8.1",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "google/apiclient": "^2.12"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.7|^6.0",
-        "phpunit/phpunit": "^8.5.8|^9.0"
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,16 +9,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
## Summary

- Adds support for **Laravel 12** and **Laravel 13** alongside the existing 9/10/11 range.
- Bumps the minimum PHP version from 7.3 to **8.1**, aligning with what actually installs today (older PHP versions were already broken by upstream `firebase/php-jwt` security advisories that block every `google/apiclient` release compatible with PHP < 8.1).
- Migrates `phpunit.xml.dist` to a schema that validates on PHPUnit 9, 10, and 11, so newer Laravel versions don't emit config warnings on test runs.

## Changes

### `composer.json`
- `php`: `^7.3|^8.0` → `^8.1`
- `illuminate/support`: `^7.0|...|^11.0` → `^9.0|^10.0|^11.0|^12.0|^13.0`
- `orchestra/testbench` (dev): `^5.7|^6.0` → `^7.0|^8.0|^9.0|^10.0|^11.0`
- `phpunit/phpunit` (dev): `^8.5.8|^9.0` → `^9.0|^10.0|^11.0`

### `phpunit.xml.dist`
Migrated to a minimal schema that validates on PHPUnit 9/10/11. Dropped attributes/elements removed in PHPUnit 10 (`backupStaticAttributes`, `verbose`, `convertErrorsToExceptions`, `convertNoticesToExceptions`, `convertWarningsToExceptions`, `<filter><whitelist>`, `<log type="…">`). Coverage configuration was already CLI-driven via the `test-coverage` script.

### `tests/ExampleTest.php`
Removed `/** @test */` doc-comment metadata (deprecated in PHPUnit 10+) and renamed the method to `testTrueIsTrue()` so PHPUnit auto-discovers it across all supported versions.

### `README.md`, `CHANGELOG.md`
Updated Requirements section and added a `2.0.0` changelog entry.

## Compatibility matrix (verified)

| PHP | Laravel resolved | PHPUnit | Result |
|-----|-----------------:|--------:|--------|
| 8.1 | 10               | 10      | PASS   |
| 8.2 | 12               | 11      | PASS   |
| 8.3 | 13               | 11      | PASS   |
| 8.4 | 13               | 11      | PASS   |

Resolution checked via `composer update --dry-run`; `vendor/bin/phpunit` additionally executed end-to-end on PHP 8.1 and 8.3 — clean run, no warnings, no deprecations.

## Breaking changes

- **PHP 7.3, 7.4, 8.0 are no longer supported.** In practice these were already non-installable because Composer's audit blocks the `firebase/php-jwt` versions pulled in by older `google/apiclient`, but the new constraint makes this explicit and produces a clearer error.
- **Laravel 7 and 8 dropped** from the supported range (both are EOL).